### PR TITLE
New Command: Generates 'setup.rb'

### DIFF
--- a/bin/gs
+++ b/bin/gs
@@ -23,6 +23,11 @@ DESCRIPTION
       help
           Displays this message.
 
+      dep
+          Creates setup.rb in $PWD/.gs directory. This setup.rb
+          loads all paths of cached gems in .gs. Requires .gems
+          file in your app's root directory.
+
       [command]
           An optional command that will be executed under gs shell
           session and return to the caller session once finished.
@@ -31,6 +36,14 @@ EOS
 case ARGV[0]
 when "init" then Dir.mkdir(".gs"); exec($0)
 when "help" then puts help
+when "dep"
+  gems = File.read "./.gems"
+  gem_names = gems.split("\n")
+  target = File.open('.gs/setup.rb', 'w')
+  gem_names.each do |gem_name|
+    dir_name = gem_name.split(' ').values_at(0,2).join('-')
+    target.write("$:.unshift File.expand_path('./gems/" + "#{dir_name}/lib')\n")
+  end
 else
   if File.directory?(".gs")
     pwd = Dir.pwd


### PR DESCRIPTION
That's why the command is called `gs dep` since it is to be used only with dep and expects a `.gems` file in the app's root directory.

It generates a `setup.rb` file which user would require in his main application file (`app.rb` in Cuba). If user requires this file, all cached .gs gems will be loaded instead of loading them from outside the app.
