### PR TITLE
use ENV['ComSpec'] if no ENV['SHELL'] 

### DIFF
--- a/bin/gs
+++ b/bin/gs
@@ -43,7 +43,7 @@ else
     if ARGV.length > 0
       exec env, *ARGV
     else
-      exec env, ENV["SHELL"]
+      exec env, ENV["SHELL"] || ENV["ComSpec"]
     end
   else
     puts "Directory .gs not found. Try `gs help`."


### PR DESCRIPTION
So gs works out of the box on windows
