### PR TITLE
fix PATH for Windows

### DIFF
--- a/bin/gs
+++ b/bin/gs
@@ -28,6 +28,14 @@ DESCRIPTION
           session and return to the caller session once finished.
 EOS
 
+native_separator = lambda { |path|
+  if sep = File::ALT_SEPARATOR
+    path.gsub(/\//, sep)
+  else
+    path 
+  end    
+}
+
 case ARGV[0]
 when "init" then Dir.mkdir(".gs"); exec($0)
 when "help" then puts help
@@ -38,7 +46,8 @@ else
     env["GS_NAME"]  = File.basename(pwd)
     env["GEM_HOME"] = pwd + "/.gs"
     env["GEM_PATH"] = pwd + "/.gs:#{`gem env path`.strip}"
-    env["PATH"]     = pwd + "/.gs/bin:#{ENV['PATH']}"
+    env["PATH"]     = native_separator[pwd + "/.gs/bin"] + File::PATH_SEPARATOR + 
+                      ENV['PATH']
 
     if ARGV.length > 0
       exec env, *ARGV


### PR DESCRIPTION
This uses platform-specific separators for paths, in building the PATH variable.  So on Windows you get backlashes and semicolons instead of forward-slashes and colons.  (The other variables shouldn't change of course since they are used by Ruby, not the shell).  Otherwise gs won't work on Windows. Meant to send this awhile ago but only getting around to it now...
